### PR TITLE
Fix background color for code snippets

### DIFF
--- a/src/components/shared/CodeExample.tsx
+++ b/src/components/shared/CodeExample.tsx
@@ -15,8 +15,8 @@ export default function CodeExample({
 		<div className={clsx(
 			'rounded-lg p-4 border-2 transition-all',
 			isActive 
-				? 'bg-gray-900 border-blue-500 shadow-lg shadow-blue-500/20' 
-				: 'bg-gray-900/70 border-gray-700'
+				? 'bg-slate-950 border-blue-500 shadow-lg shadow-blue-500/20' 
+				: 'bg-slate-950/95 border-slate-700 hover:border-slate-600'
 		)}>
 			<h3 className='text-white font-semibold mb-2 text-sm flex items-center gap-2'>
 				{title}


### PR DESCRIPTION
## Description
Updates the background styling of code snippets in the Effect Fundamentals section to resolve the "weird gray" appearance. The `CodeExample` component now uses a darker, more modern slate theme for improved aesthetics.

## Changes Made
- [ ] Added new feature demonstration
- [x] Fixed bug in existing functionality  
- [ ] Improved documentation
- [x] Refactored code (styling updates)
- [ ] Updated dependencies
- [ ] Other: _________

## Effect Features Demonstrated
N/A

## Testing
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested on mobile
- [x] All interactive controls work
- [x] Code examples are accurate
- [x] Build passes (`npm run build`)
- [x] Linting passes (`npm run lint`)

## Screenshots
(Not applicable)

## Breaking Changes
- [ ] This PR includes breaking changes
- [x] This PR does not include breaking changes

## Related Issues
N/A

## Additional Notes
Changed `bg-gray-900` to `bg-slate-950` and `bg-gray-900/70` to `bg-slate-950/95`. Also updated border colors to `border-slate-700` and added `hover:border-slate-600` for a cleaner look and better interactivity.